### PR TITLE
add adobe PDF to docx nodes doc hooks

### DIFF
--- a/articles/flow/actions/adobe/adobe-connection.md
+++ b/articles/flow/actions/adobe/adobe-connection.md
@@ -1,0 +1,1 @@
+# Adobe PDF Services connection

--- a/articles/flow/actions/adobe/pdf-to-docx-as-byte-array.md
+++ b/articles/flow/actions/adobe/pdf-to-docx-as-byte-array.md
@@ -1,0 +1,1 @@
+# PDF to docx as byte array

--- a/articles/flow/actions/adobe/pdf-to-docx-as-stream.md
+++ b/articles/flow/actions/adobe/pdf-to-docx-as-stream.md
@@ -1,0 +1,1 @@
+# PDF to docx as stream

--- a/articles/flow/actions/adobe/toc.yml
+++ b/articles/flow/actions/adobe/toc.yml
@@ -1,0 +1,9 @@
+- name: "Connection"
+  href: "adobe-connection.md"
+- name: "PDF to docx as byte array"
+  href: "pdf-to-docx-as-byte-array.md"
+- name: "PDF to docx as stream"
+  href: "pdf-to-docx-as-stream.md"
+
+
+ 

--- a/articles/flow/toc.yml
+++ b/articles/flow/toc.yml
@@ -64,6 +64,8 @@
       href: flows/modularization-and-extensions.md
 - name: Actions
   items:
+    - name: Adobe
+      href: actions/adobe/toc.yml 
     - name: Agents
       href: actions/agents/toc.yml      
     - name: AI


### PR DESCRIPTION
This PR will add hooks for documentation of 
- Adobe connection
- PDF to Docx as byte array
- PDF to Docx as stream