### PR TITLE
Rename Blob Storage connection to Blob Container connection

### DIFF
--- a/articles/flow/triggers/azure-blob-storage/blob-trigger.md
+++ b/articles/flow/triggers/azure-blob-storage/blob-trigger.md
@@ -13,7 +13,7 @@ Configures the flow to automatically run by periodically fetching a list of all 
 | Name           | Type     | Description                                      |
 |----------------|----------|--------------------------------------------------|
 | Title          |          |                                                  |
-| Connection     | Required | Connection name and string.                      |
+| Connection     | Required | [Azure Blob container connection](../../actions/azure-blob-storage/azure-blob-container-connection.md)                  |
 | Polling frequency| Optional | Schedule configuration of the trigger.         |
 | Blob name prefix filter | Optional | Prefix filter for blob names.           |
 | Disabled       | Optional | Boolean value indicating whether the trigger is disabled (true/false).|

--- a/articles/flow/triggers/azure-blob-storage/incremental-blob-trigger.md
+++ b/articles/flow/triggers/azure-blob-storage/incremental-blob-trigger.md
@@ -12,7 +12,7 @@ Configures the flow to automatically run by periodically checking for new or mod
 | Name           | Type     | Description                                      |
 |----------------|----------|--------------------------------------------------|
 | Title          |          |                                                  |
-| Connection     | Required | Connection name and string.                      |
+| Connection     | Required | [Azure Blob container connection](../../actions/azure-blob-storage/azure-blob-container-connection.md)               |
 | Polling frequency| Optional | Schedule configuration of the trigger.         |
 | Number of blobs | Optional |                                                 |
 | Disabled       | Optional | Boolean value indicating whether the trigger is disabled (true/false).|

--- a/articles/flow/triggers/azure-event-hub/event-hub-trigger.md
+++ b/articles/flow/triggers/azure-event-hub/event-hub-trigger.md
@@ -10,7 +10,7 @@ When a new message arrives in the [Azure Event hub](https://learn.microsoft.com/
 |----------------|----------|--------------------------------------------------|
 | Title          |  Optional | A descriptive label for the trigger configuration.|
 | Event Hub connection     | Required | Azure Event Hub connection used to authenticate and connect to the service. |
-| Blob storage connection     | Required | Azure Blob Storage connection used to maintain the checkpoint. |
+| Blob Container connection     | Required | [Azure Blob container connection](../../actions/azure-blob-storage/azure-blob-container-connection.md) used to maintain the checkpoint. |
 | Polling frequency| Optional | Interval or schedule for how often the trigger checks for new messages in the topic. |
 | Checkpoint batch size | Optional | Specifies the number of received event before updating the checkpoint. |
 | Consumer group | Optional | Specifies the name of the consumer group used to read the events. |


### PR DESCRIPTION
This PR will:
- Rename _Blob Storage connection_ to _Blob Container connection_ in the Azure Event Hub trigger
- Add links to _Blob Container connection_ page in both Azure Blob Storage and Azure Event Hub triggers 