### PR TITLE
overview pages in invision and planner

### DIFF
--- a/articles/flow/changelog.md
+++ b/articles/flow/changelog.md
@@ -1,13 +1,17 @@
-
 # Change Log
 
 ### What's new?
 
 Learn about the cool new features, updates, and bug fixes.
 
+- [February 2026](changelog/release-notes-feb-2026.md)
+- [December 2025](changelog/release-notes-dec-2025.md)
+- [October 2025](changelog/changelog25_october.md)
+- [September 2025](changelog/changelog25_september.md)
+- [June 2025](changelog/changelog25_june.md)
+- [May 2025](changelog/changelog25_may.md)
 - [February 2025](changelog/changelog25_february.md)
 - [December 2024](changelog/changelog24_december.md)
 - [October 2024](changelog/changelog24_october.md)
 - [September 2024](changelog/changelog24_september.md)
 - [August 2024](changelog/changelog24_august.md)
-

--- a/articles/invision/changelog.md
+++ b/articles/invision/changelog.md
@@ -1,9 +1,10 @@
-
 # Change Log
 
 ### What's new?
 
 Learn about the cool new features, updates, and bug fixes.
+
+- [Change Log 2026.1](../invision/changelog/changelog26_1.md)
 - [Change Log 2025.6](../invision/changelog/changelog25_6.md)
 - [Change Log 2025.5](../invision/changelog/changelog25_5.md)
 - [Change Log 2025.4](../invision/changelog/changelog25_4.md)
@@ -11,7 +12,6 @@ Learn about the cool new features, updates, and bug fixes.
 - [Change Log 2025.2](../invision/changelog/changelog25_2.md)
 - [Change Log 2025.1](../invision/changelog/changelog25_1.md)
 - [Change Log 2024.5](../invision/changelog/changelog24_5.md)
-- [Change Log 2025.1](../invision/changelog/changelog25_1.md)
 - [Change Log 2024.4](../invision/changelog/changelog24_4.md)
 - [Change Log 2024.3](../invision/changelog/changelog24_3.md)
 - [Change Log 2024.2](../invision/changelog/changelog24_2.md)
@@ -28,11 +28,9 @@ Learn about the cool new features, updates, and bug fixes.
 - [Change Log 2022.3 pt 2](../invision/changelog/changelog22_3_2.md)
 - [Change Log 2022.3 pt 1](../invision/changelog/changelog22_3_1.md)
 - [Change Log 2022.2](../invision/changelog/changelog22_2.md)
+- [Change Log 2022.1](../invision/changelog/changelog22_1.md)
 - [Change Log 5.2](../invision/changelog/changelog52.md)
 - [Change Log 5.1](../invision/changelog/changelog51.md)
 - [Change Log 5.0](../invision/changelog/changelog5.md)
 - [Change Log 4.1](../invision/changelog/changelog41.md)
 - [Change Log 4.0](../invision/changelog/changelog40.md)
-
-
-- [Change Log 4.0](../invision/changelog/changelog22_3_2.md)

--- a/articles/invision/docs/bestpractice/overview.md
+++ b/articles/invision/docs/bestpractice/overview.md
@@ -1,3 +1,24 @@
 # Best practice
 
-_This page is under construction._
+This section provides guidance and recommended practices for building solutions in InVision. The recommendations here come from Profitbase and reflect patterns that have proven effective in real-world implementations. This guidance will continue to be updated as new patterns and recommendations emerge.
+
+## Why best practices matter
+
+Following established patterns when building an InVision solution leads to projects that are easier to navigate, maintain, and hand over. A consistent structure helps team members find what they need, reduces the time spent untangling unclear references, and makes the solution more resilient as it grows.
+
+InVision does not enforce any particular structure — you are free to organize your solution as you see fit. The recommendations in this section are the patterns Profitbase suggests as a sensible default.
+
+## In this section
+
+- [Guidance for InVision](bestpractice.md) — general getting-started recommendations, including the importance of folder structure and naming
+- [Basic guidelines for structuring solutions](structuringsolution.md) — detailed guidance on organizing solution components by feature/business area, working with namespaces, and applying logical structure across data flows, data stores, and other resources
+
+## Getting started
+
+If you are new to InVision, the most important habit to establish early is keeping your solution organized:
+
+- **Use folders** to group related items. A solution that grows without folder structure quickly becomes difficult to navigate.
+- **Choose sensible names** for the items you create. Names tend to be referenced in many places throughout a solution, and renaming later is more disruptive than naming well from the start.
+- **Structure by feature, not by type.** Group everything that belongs to "Budget" together, rather than putting all data flows in one folder and all data stores in another.
+
+For more detail on each of these points, see the linked pages above.

--- a/articles/invision/docs/forms/formschemas/functions/overview.md
+++ b/articles/invision/docs/forms/formschemas/functions/overview.md
@@ -1,3 +1,26 @@
 # Functions
 
-_This page is under construction._
+Functions in Form Schemas let you define reusable JavaScript logic that can be called from Event Handlers or from other Functions. This makes it possible to centralize business logic for a schema and avoid duplicating the same code across multiple event handlers.
+
+## What functions are
+
+A function configuration is converted directly into a JavaScript function and added as an instance method on the Form Runtime of the schema. Once defined, you can call it through the `functions` or `this` keyword from anywhere in the schema where script runs.
+
+Functions support standard JavaScript syntax (whatever the browser supports natively — no TypeScript or Babel transpilation), accept comma-separated parameters, and can be marked `Async` to allow the use of `await`.
+
+## When to use functions
+
+Reach for a function when you find yourself writing the same logic in more than one Event Handler, or when an Event Handler is becoming long enough to be hard to read. Pulling the logic into a named function makes the schema easier to maintain and the intent clearer at the call site.
+
+Functions are also the entry point for triggering Form Schema logic from outside the schema — for example, from a button click on the workbook. See [Calling functions from external events](callingfunctions.md) for that pattern.
+
+## In this section
+
+- [Functions](../functions.md) — full reference including properties, async functions, and detailed examples
+- [Calling functions from external events](callingfunctions.md) — how to invoke a Form Schema function from other workbook components
+
+## Videos
+
+- [Form Schemas](../../../../videos/formschemas.md)
+- [Functions](https://profitbasedocs.blob.core.windows.net/videos/Form%20Schema%20-%20Function.mp4)
+- [Calling Functions from External Events](https://profitbasedocs.blob.core.windows.net/videos/Form%20schema%20-%20Calling%20Functions.mp4)

--- a/articles/invision/docs/header/overview.md
+++ b/articles/invision/docs/header/overview.md
@@ -1,3 +1,18 @@
 # Header
 
-_This page is under construction._
+The App Header is the toolbar at the top of the InVision Designer. This section covers the options available for customizing the header and the built-in feedback functionality that ships with it.
+
+## What you can configure
+
+The header is made of two main capabilities. The **App Header section** lets you change how the toolbar looks and what it contains — including its design, custom content, and the spacing it occupies in the Designer. The **Feedback** functionality provides a built-in way for users to send feedback directly from the InVision client, with configurable recipient addresses and mood indicators.
+
+## In this section
+
+- [Show App Header section](header-section.md) — enable the App Header section in the Designer, customize its appearance, and add components to the toolbar
+- [Feedback](feedback.md) — configure the feedback feature, change recipients via Solution Variables, and review what gets included in the feedback email
+
+## When to use these settings
+
+Customize the App Header section when you want a consistent branded look across solutions, when you need quick access to specific actions from the toolbar, or when you want to reclaim the spacing it takes up in the Designer.
+
+The Feedback feature is useful for collecting input from end users directly within the solution. Routing feedback to a specific email address per solution is straightforward via the `FEEDBACK_EMAILTO` Solution Variable.

--- a/articles/invision/docs/workbooks/components/filter/overview.md
+++ b/articles/invision/docs/workbooks/components/filter/overview.md
@@ -1,3 +1,31 @@
 # Filter
 
-_This page is under construction._
+Filters are components that define the data context for other parts of a Solution — including Worksheets, Reports, Workflows, Data Flows, and Settings. Once a Filter is defined, any data context-aware component can use it by binding to one of its properties.
+
+## What a filter is
+
+A Filter is a reference to a table resource (Dimension, Fact, Setting, Data Store, or View) plus a configuration that describes how to read data from that resource. You add filters to a Workbook by dragging them from the Toolbox in the Workbook designer, then setting their properties and wiring them up through Workbook events and actions.
+
+## What you can do with filters
+
+Filters expose a number of options for controlling how they appear and behave:
+
+- **Show and hide** — toggle filter visibility through the `Is Hidden` property, an `Is Hidden Expression`, or dynamically via `Show()`, `Hide()`, `ShowIf()`, and `HideIf()` instructions
+- **Custom headings** — set a static `Header`, use a `Header Expression` for localized headings (commonly with the `Localize(...)` function), or change the heading at runtime via `SetHeader()`, `SetHeaderSuffix()`, and `ResetHeader()`
+- **Slicing** — restrict a hierarchical filter to a specific subset of leaf-level members, useful when one filter should only show items relevant to the current data context
+
+## In this section
+
+- [Filter](../filter.md) — full reference, including how to add filters to a Workbook, configure their properties, wire up events and actions, and control visibility and headings
+- [Filter slicing](filterslicing.md) — restrict a filter to a specific subset of items by calling `SetLeafLevelConstraints(...)` in the Load Data action
+
+## See also
+
+- [More about Filters](../../../filters/index.md)
+- [Filtering Tables](../../../tables/filters.md)
+- [Filtering Worksheets](../../../worksheets/filters.md)
+
+## Videos
+
+- [Filters](../../../../videos/filters.md)
+- [Workbooks](../../../../videos/workbooks.md)

--- a/articles/invision/docs/worksheets/wproperties/overview.md
+++ b/articles/invision/docs/worksheets/wproperties/overview.md
@@ -1,3 +1,25 @@
 # Worksheet properties
 
-_This page is under construction._
+Worksheet properties control how a Worksheet behaves and what end users can do with it. These properties cover the visual appearance of the grid, the rules for adding and editing rows, sorting and filtering options, and the context menu actions available on right-click.
+
+## What you can configure
+
+Properties on a Worksheet fall into a few groups:
+
+- **Appearance** — toggle grid lines, the row selector, and the summary row to control how the grid looks
+- **Editing rules** — control row addition through Add Row Settings, decide whether row locking is exposed to users, and constrain the input level required for editing
+- **User interaction** — enable or disable column sorting and inline filtering for end users
+- **Context menu** — choose which right-click actions are available (Select All, Export to Excel, Copy/Paste, Insert row, Distribute value, Factor multiplication, Reverse distribution, Edit comments, View changes, and more)
+
+## Conditional behavior
+
+Most context menu options support three states: always available (`Yes`), hidden (`No`), or conditional based on a JavaScript function. A conditional option lets you check the selected rows, the right-clicked column, or any Workbook variable, and decide at runtime whether the option should be enabled. This is useful for restricting actions like Distribute value to specific account types, or hiding View changes for rows where Change Tracking is not relevant.
+
+## In this section
+
+- [Worksheet properties](../wproperties.md) — full reference for all available properties, including detailed descriptions of each context menu action
+- [Context menu options](contextmenuoptions.md) — how to write conditions that control when context menu options are available, including examples and the structure of the `args` parameter
+
+## See also
+
+- [Custom action conditions](../columnproperties/customactionconditions.md)

--- a/articles/planner/changelog/changelog.md
+++ b/articles/planner/changelog/changelog.md
@@ -1,7 +1,0 @@
-# Changelog
-
-## What's new?
-
-Learn about the cool new features, updates, and bug fixes.
-
-[Profitbase EPM - Current version](EPM-current.md)


### PR DESCRIPTION
# Improve content for InVision and Planner overview pages

## What was done

Replaced placeholder _"This page is under construction"_ overviews with proper landing pages, and improved a few existing index pages.

### InVision — overview pages

Filled in landing pages for sections that were previously placeholders. Each new overview includes a short intro, a summary of what's in the section, and links to the detailed pages:

- `articles/invision/docs/bestpractice/overview.md`
- `articles/invision/docs/header/overview.md`
- `articles/invision/docs/forms/formschemas/functions/overview.md`
- `articles/invision/docs/workbooks/components/filter/overview.md`
- `articles/invision/docs/worksheets/wproperties/overview.md`

### Planner — changelog and end user help

Replaced minimal placeholders with proper landing pages containing organized links to all relevant content:

- `articles/planner/changelog/overview.md` — links to all EPM changelogs (Common, Datamart, Planner, Reporting, Finance Reports, upgrade notes)
- `articles/planner/changelog/archive.md` — reorganized archived changelogs into sections (General, EPM Common, EPM Datamart, EPM Planner, EPM Reporting, Upgrade Notes)
- `articles/planner/enduserhelp/overview.md` — links to all V6.1 module guides (Account, CapEx, Loan, Personnel, Driver-based, plus Customization patterns and Data requirements)

### InVision and Flow — changelog index pages

Updated the top-level changelog landing pages to include all available versions:

- `articles/invision/changelog.md` — added missing **2026.1** and **2022.1**, removed duplicate 2025.1, fixed broken last entry
- `articles/flow/changelog.md` — added missing **February 2026, December 2025, October 2025, September 2025, June 2025, May 2025**

### Cleanup

- Deleted `articles/planner/changelog/changelog.md` — orphaned file, not linked anywhere in navigation; replaced by the new `overview.md`
