### PR TITLE
Api ref

### DIFF
--- a/articles/flow/actions/sql-server/toc.yml
+++ b/articles/flow/actions/sql-server/toc.yml
@@ -48,5 +48,5 @@
   href: "truncate-table.md"
 - name: "Update entity"
   href: "update-entity.md"
-- name: Vector search tools
-  href: "vector-search-tools.md"
+- name: "Vector search tool"
+  href: "vector-search-tool.md"

--- a/articles/flow/api-reference/data-analysis/json/overview.md
+++ b/articles/flow/api-reference/data-analysis/json/overview.md
@@ -1,3 +1,15 @@
-# JSON
+# JSON overview
 
-_This page is under construction._
+The **JSON** helpers in Data Analysis make it easy to flatten and read JSON content from inside a [Function](./../../../actions/built-in/function.md) action — when the JSON-handling [actions](./../../../actions/json/overview.md) don't fit and you want to drive the parsing yourself in C#. The classes implement the standard .NET data-reading interfaces, so their output can be piped directly into any action that accepts a DataReader.
+
+<br/>
+
+## Explore
+
+#### Reading JSON as rows
+[JsonDataReader](./json-data-reader/json-data-reader.md) reads a JSON string as a forward-only sequence of rows, implementing `IDataReader` and `IDataRecord`. Use it when you want to flatten a JSON document into tabular form — for example to insert it into a database table or pipe it through another DataReader-accepting action.
+
+<br/>
+
+#### Defining the schema
+[JsonDataReaderSchema](./json-data-reader/json-data-reader-schema.md) defines how JSON properties map to columns: the JSON property name to read, the column name in the output, and the target data type. Pass an instance of this to JsonDataReader to control exactly which fields are extracted and how they're typed.

--- a/articles/flow/api-reference/data-analysis/overview.md
+++ b/articles/flow/api-reference/data-analysis/overview.md
@@ -1,3 +1,15 @@
-# Data Analysis
+# Data Analysis overview
 
-_This page is under construction._
+The **Data Analysis** APIs provide helper classes for transforming and reading data inside a [Function](./../../actions/built-in/function.md) action — when the standard actions in a category don't cover what you need and you want to write the logic yourself in C#. The classes are designed to integrate naturally with .NET's `DataTable`, `IDataReader`, and similar built-in types.
+
+<br/>
+
+## Explore
+
+#### Transforming DataTables
+[DataTableTransformer](./datatable-transformer/datatable-transformer.md) applies a sequence of transformations to a `DataTable` — renaming columns, changing data types, replacing values, removing rows. Accessed by calling the `UseTransform()` extension method on any `DataTable` instance.
+
+<br/>
+
+#### Reading JSON
+[JSON](./json/overview.md) provides helpers for flattening JSON content into rows and columns. [JsonDataReader](./json/json-data-reader/json-data-reader.md) reads a JSON string as a forward-only sequence of rows, implementing the standard `IDataReader` interface so the result can be piped directly into any action that accepts a DataReader. [JsonDataReaderSchema](./json/json-data-reader/json-data-reader-schema.md) defines the mapping between JSON properties and target column names and data types.

--- a/articles/flow/api-reference/overview.md
+++ b/articles/flow/api-reference/overview.md
@@ -1,3 +1,25 @@
-# API reference
+# API reference overview
 
-_This page is under construction._
+This section contains reference documentation for Flow's HTTP APIs and the built-in types used across Flow definitions. Use these pages when you need exact request and response shapes for calling a Flow from an external system, looking up the structure of a built-in type returned by an action, or working with the data-manipulation classes available inside [Function](./../actions/built-in/function.md) actions.
+
+<br/>
+
+## Explore
+
+#### Executing Flows
+The HTTP endpoints for triggering a Flow from outside the Designer. [Run](./execute-flow/run.md) executes a Flow synchronously and returns the response, with a five-minute maximum execution time. [Run streaming](./execute-flow/stream.md) executes a Flow that streams data back to the client as it's produced — useful for chat-style responses. [Submit](./execute-flow/submit-long-running.md) starts a long-running Flow and returns a job ID immediately, and [Poll](./execute-flow/poll.md) checks the status of a submitted job and returns its log entries.
+
+<br/>
+
+#### Logs
+The HTTP endpoints for retrieving Flow execution history. [Get Runs](./logs/get-runs.md) lists past runs of a specific Flow, and [Get Run log](./logs/get-run-log.md) returns the full log entries for an individual run.
+
+<br/>
+
+#### Built-in types
+Reference documentation for the types used by actions across Flow. [DeltaSet](./built-in-types/deltaset.md) represents a collection of inserts, updates, and deletes that can be applied to a database, file, or service — used by Power BI writeback triggers and the matching Save DeltaSet actions. [HttpResponse](./built-in-types/http-response.md) represents the response from an HTTP API call, including the data, status code, and error information. [IVectorSearchResult](./built-in-types/ai/i-vector-search-result.md) represents the result of a vector similarity search and can be passed directly to a chat completion action as context.
+
+<br/>
+
+#### Data Analysis
+APIs for manipulating data inside a [Function](./../actions/built-in/function.md) action — see [Data Analysis](./data-analysis/overview.md) for the full reference, including DataTableTransformer for reshaping DataTables and JsonDataReader for flattening JSON into rows.

--- a/articles/flow/api-reference/toc.yml
+++ b/articles/flow/api-reference/toc.yml
@@ -18,8 +18,10 @@
   items:
     - name: "DeltaSet"
       href: "built-in-types/deltaset.md"
-    - name: HttpReponse
-      href: built-in-types/http-response.md
+    - name: "HttpResponse"
+      href: "built-in-types/http-response.md"
+    - name: "IVectorSearchResult"
+      href: "built-in-types/ai/i-vector-search-result.md"
 - name: Data Analysis
   href: data-analysis/toc.yml
   topicHref: data-analysis/overview.md


### PR DESCRIPTION
# Add overview pages for the API reference section

## What

Fills in three *"This page is under construction"* placeholders in the API reference section of the Flow documentation:

- **`articles/flow/api-reference/overview.md`** — top-level landing page for the API reference, grouping the HTTP endpoints and built-in types by purpose.
- **`articles/flow/api-reference/data-analysis/overview.md`** — landing page for the Data Analysis helpers used inside Function actions.
- **`articles/flow/api-reference/data-analysis/json/overview.md`** — landing page for the JSON helpers (JsonDataReader, JsonDataReaderSchema).

Together with the earlier PRs (per-category overviews + Actions/Triggers parent pages), this completes the overview layer across the Flow documentation.

## Also fixed

- **`articles/flow/api-reference/toc.yml`** — fixed the sidebar label `HttpReponse` → `HttpResponse` (the file itself was already correct), and added `IVectorSearchResult` under Built-in types. The file already existed at `built-in-types/ai/i-vector-search-result.md` and is referenced by the PostgreSQL and SQL Server vector search actions, but wasn't visible in the sidebar.

## Goals

- **Clarity** — each page opens by saying what the section is for and when to reach for it, instead of jumping straight into a list of links.
- **Structure** — endpoints and types are grouped by purpose (executing Flows, reading logs, built-in types, data manipulation) rather than listed flat.
- **Consistency** — same pattern as the Actions and Triggers overviews from the previous PRs (intro → "Explore" sections with prose linking to subpages).
- **Cross-linking** — DeltaSet ↔ Power BI writeback triggers, Data Analysis ↔ Function action, JSON helpers ↔ JSON actions — so readers can move between related areas without backtracking.
- **Faithful to the docs** — content is grounded in the actual subpages, with no invented endpoints, types, or behaviors.