### PR TITLE
docs: add missing how-to links to landing pages

### DIFF
--- a/articles/invision/docs/dimensions/howto/index.md
+++ b/articles/invision/docs/dimensions/howto/index.md
@@ -10,5 +10,7 @@ In this section, you will find a list of shortcuts to different subjects about D
 * [How to Configure Translation of Dimensions Name](transl.md)
 * [How To Create and Display Dimension](createdim.md)
 * [How To Create a Time Dimension](timedim.md)
+* [How To Compose Dimension](dimcomp.md)
+* [Set default data for new dimension members](set-default-data-for-new-dimension-members.md)
 
 

--- a/articles/invision/docs/flows/overview.md
+++ b/articles/invision/docs/flows/overview.md
@@ -12,4 +12,5 @@ Read more:
 [Add a Flow to a Solution](./how-to/add-flow-to-solution.md)  
 [Run Flows from a Form](./how-to/run-flow-from-form-schema.md)  
 [Run Flows from a Workbook](./how-to/run-flow-from-workbook.md)  
-[Run long-running Flows](./how-to/run-long-running-flow.md)
+[Run long-running Flows](./how-to/run-long-running-flow.md)  
+[Download file from Flow](./how-to/download-file-from-flow.md)

--- a/articles/invision/docs/systemsetup/howto.md
+++ b/articles/invision/docs/systemsetup/howto.md
@@ -1,7 +1,7 @@
 
 # How to's
 
-In this section, you will find a list of shortcuts to different subjects about Dimesions.
+In this section, you will find a list of shortcuts to different subjects about System Setup.
 
 <br/>
 
@@ -13,6 +13,7 @@ In this section, you will find a list of shortcuts to different subjects about D
 * [How To Setup InVision Service with Azure Active Directory Authentication](howto/ad-authentication.md)
 * [How To Setup InVision Service with Windows Authentication](howto/win-authentication.md)
 * [How To Upgrade the InVision Instance](howto/instance.md)
+* [How To Create Entra ID App Registrations](howto/entra-id-app-registrations.md)
 
 
 

--- a/articles/invision/docs/systemsetup/howto/index.md
+++ b/articles/invision/docs/systemsetup/howto/index.md
@@ -3,6 +3,7 @@
 * [Ad authentication](./ad-authentication.md)
 * [Azure registration](./azure-registration.md)
 * [Azuread](./azuread.md)
+* [Entra id app registrations](./entra-id-app-registrations.md)
 * [Install](./install.md)
 * [Instance](./instance.md)
 * [Win authentication](./win-authentication.md)

--- a/articles/invision/docs/workbooks/howto.md
+++ b/articles/invision/docs/workbooks/howto.md
@@ -18,3 +18,4 @@ In this section, you will find a list of shortcuts to different subjects about W
 * [How To Set Up Interactions in Workbook](howto/interactions.md)
 * [How To Work with Components in Workbook](howto/components.md)
 * [How To Stack Components](howto/componentstacking.md)
+* [How To Initialize Workbook From URL](howto/initializing.md)

--- a/articles/invision/docs/workbooks/howto/index.md
+++ b/articles/invision/docs/workbooks/howto/index.md
@@ -3,6 +3,7 @@
 * [Components](./components.md)
 * [Componentstacking](./componentstacking.md)
 * [Creatingworkbook](./creatingworkbook.md)
+* [Initializing](./initializing.md)
 * [Interactions](./interactions.md)
 * [Popup](./popup.md)
 * [Stepperbasic](./stepperbasic.md)


### PR DESCRIPTION
- dimensions/howto/index.md: add dimcomp and set-default-data-for-new-dimension-members
- flows/overview.md: add download-file-from-flow
- systemsetup/howto.md: add entra-id-app-registrations, fix 'Dimesions' typo
- systemsetup/howto/index.md: add entra-id-app-registrations
- workbooks/howto.md: add initializing
- workbooks/howto/index.md: add initializing