### PR TITLE
added docs for anomaly detection, corrected docs after pr, added addi…

### DIFF
--- a/articles/flow/actions/hypergene-devops/clone-invision-deployment.md
+++ b/articles/flow/actions/hypergene-devops/clone-invision-deployment.md
@@ -37,3 +37,6 @@ A `CloneDeploymentResult` object with the following properties:
 > Cloning a deployment is a long-running operation. The Flow containing this action must be configured to run in long-running mode.
 
 <br/>
+
+> [!NOTE]
+> If the source Hypergene InVision deployment has a connected Flow deployment, that Flow deployment is cloned as well and automatically connected to the new InVision clone.

--- a/articles/flow/actions/hypergene-devops/connection.md
+++ b/articles/flow/actions/hypergene-devops/connection.md
@@ -1,16 +1,15 @@
 # AllSpark connection
 
-To use any of the [Hypergene DevOps actions](./overview.md), you need to either select an existing **AllSpark connection** or create a new one. The connection holds the AllSpark API endpoint and the credentials used to authenticate, and is reused across actions in this category.
-
+To use any of the [Hypergene DevOps actions](./overview.md), you need to either select an existing **AllSpark connection** or create a new one. The connection holds the AllSpark environment selection and the credentials used to authenticate, and is reused across actions in this category.
 
 ## Properties
 
 | Name          | Required | Description |
 |---------------|----------|-------------|
 | Name          | No  | A custom name for the connection. This will be shown when selecting it in Flow actions. |
-| Api           | Yes | The AllSpark API endpoint to connect to (for example, `dev.allspark.profitbase.biz`). |
-| Tenant Id     | Yes | The tenant identifier used to authenticate against AllSpark. |
-| Client Id     | Yes | The client identifier used to authenticate against AllSpark. |
+| Api           | Yes | The AllSpark environment to connect to. Select either **AllSpark Development** or **AllSpark Production**. |
+| Tenant Id     | Yes | The tenant identifier used to authenticate against AllSpark. Use `Profitbase AS`. |
+| Client Id     | Yes | The client identifier used to authenticate against AllSpark. Use `allspark-api`. |
 | Client secret | Yes | The client secret used to authenticate against AllSpark. |
 
 <br/>
@@ -18,9 +17,9 @@ To use any of the [Hypergene DevOps actions](./overview.md), you need to either 
 ## Configuration steps
 
 1. Provide a **Name** for the connection.
-2. Enter the **Api** endpoint of the AllSpark environment you want to connect to.
-3. Enter the **Tenant Id**, **Client Id**, and **Client secret** issued for your AllSpark integration.
+2. Select the **Api** — either **AllSpark Development** or **AllSpark Production** — depending on the AllSpark environment you want to connect to.
+3. Enter the **Tenant Id** (`Profitbase AS`), **Client Id** (`allspark-api`), and the **Client secret** issued for your AllSpark integration.
 4. Click **Test connection** to verify the setup.
 5. If the test is successful, click **Ok** to save the connection.
 
-![AllSpark Connection](../../../../images/flow/allspark-connection.png)
+<!--![AllSpark Connection](../../../../images/flow/allspark-connection.png)-->

--- a/articles/flow/actions/hypergene-devops/delete-invision-deployment.md
+++ b/articles/flow/actions/hypergene-devops/delete-invision-deployment.md
@@ -42,3 +42,5 @@ A `DeleteDeploymentResult` object with the following property:
 
 <br/>
 
+> [!IMPORTANT]
+> If the deleted Hypergene InVision deployment has a connected (cloned) Flow deployment, that Flow deployment is deleted as well.

--- a/articles/flow/actions/hypergene-devops/overview.md
+++ b/articles/flow/actions/hypergene-devops/overview.md
@@ -14,5 +14,10 @@ To use any Hypergene DevOps action, you first need an [AllSpark connection](./co
 
 <br/>
 
+> [!IMPORTANT]
+> Both actions cascade to connected Flow deployments. If the Hypergene InVision deployment has a Flow deployment connected to it, that Flow deployment is cloned alongside the InVision instance, or deleted together with it. The cloned Flow deployment is automatically connected to the cloned InVision instance.
+
+<br/>
+
 > [!NOTE]
 > Both actions are long-running. The Flow containing them must be configured to run in long-running mode.

--- a/articles/flow/actions/machine-learning/anomaly-detection.md
+++ b/articles/flow/actions/machine-learning/anomaly-detection.md
@@ -1,0 +1,96 @@
+# Anomaly Detection
+
+The **Anomaly Detection** node identifies unusual data points in tabular numeric datasets using the [Isolation Forest](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.IsolationForest.html) algorithm. Each detected anomaly is accompanied by a SHAP-based explanation that describes which features contributed most to the anomalous classification.
+
+## Use cases
+
+- Detecting fraudulent transactions or outlier financial entries
+- Flagging sensor readings that deviate from expected operating ranges
+- Identifying data quality issues or data entry errors in large datasets
+- Spotting unusual demand patterns or inventory movements
+
+## Example
+
+A dataset of sales transactions is uploaded. The node runs Isolation Forest on the `quantity` and `unit_price` columns. The result contains only the rows classified as anomalous, with an `anomaly_score` indicating how strongly anomalous each row is and an `anomaly_explanation` summarising which features drove the classification.
+
+## Prerequisites
+
+- A configured **Forecast ML service** connection in the Flow solution.
+- Input data in **CSV** or **Parquet** format.
+- All feature columns must be **numeric** (non-numeric values will cause the job to fail).
+
+## Properties
+
+| Name | Required | Description |
+|---|---|---|
+| Input contents | Yes | The data to analyse. Accepts `byte[]`, `DataTable`, `IDataReader`, or `Stream`. |
+| Input file format | Conditional | Required when **Input contents** is `byte[]` or `Stream`. Set to `csv` or `parquet` to tell the service how to parse the raw bytes. |
+| Output file format | Yes | Format of the result file returned by the service. `csv` or `parquet`. |
+| Feature columns | Yes | Comma-separated list of column names to use for anomaly detection. Only these columns are passed to the model; all other columns are preserved in the output. |
+| Number of estimators | Yes | Number of trees in the Isolation Forest ensemble. Defaults to `100`. Higher values improve accuracy at the cost of longer run time. |
+| Contamination | No | Expected proportion of anomalies in the dataset. Must be in the range `(0, 0.5)`. Leave empty to use `"auto"`, which lets the algorithm infer a threshold from the data. |
+| Return variable name | Yes | Name of the C# variable that will hold the result (`byte[]`). Must be a valid C# identifier. |
+
+## Input contents
+
+The node accepts four input types:
+
+| Type | Notes |
+|---|---|
+| `byte[]` | Raw file bytes. **Input file format** must be set. |
+| `Stream` | File stream. **Input file format** must be set. |
+| `DataTable` | Automatically serialised to Parquet before upload. **Input file format** is not required. |
+| `IDataReader` | Automatically serialised to Parquet before upload. **Input file format** is not required. |
+
+> [!IMPORTANT]
+> All columns listed in **Feature columns** must exist in the input file and contain numeric data. The node validates column presence before running the model and will fail with a descriptive error if any feature column is missing.
+
+## Output data
+
+The result contains **only the rows classified as anomalies**. All original columns from the input are preserved, and two additional columns are appended:
+
+| Column | Type | Description |
+|---|---|---|
+| `anomaly_score` | float | Anomaly score from the Isolation Forest model. Higher values indicate a stronger deviation from normal. |
+| `anomaly_explanation` | string | SHAP-based feature explanation. Lists each feature with its value, whether it was above or below the dataset mean, and its SHAP impact score. Features are sorted by absolute impact, descending. |
+
+If no anomalies are detected, the result is an **empty dataset** with the full column set (including `anomaly_score` and `anomaly_explanation`).
+
+##### Example anomaly_explanation value
+```
+quantity: 9500 (above normal, impact +0.3812); unit_price: 0.01 (below normal, impact +0.1204)
+```
+
+## Configuration
+
+### Feature columns
+
+Specify the column names the model should use as input features, separated by commas:
+
+```
+quantity, unit_price, discount
+```
+
+Only numeric columns should be listed. The model fits exclusively on these columns, but all columns in the source data are included in the output.
+
+### Contamination
+
+Controls the decision threshold used to classify a row as anomalous.
+
+| Value | Behaviour |
+|---|---|
+| Empty (default) | `"auto"` — threshold is derived from the training data distribution |
+| `0.05` | Approximately 5 % of rows will be flagged as anomalies |
+| `0.1` | Approximately 10 % of rows will be flagged |
+
+Setting an explicit value is useful when you have domain knowledge about the expected anomaly rate. Values must be in the **open interval (0, 0.5)** — zero and 0.5 are not allowed.
+
+### Number of estimators
+
+The number of decision trees built by the ensemble. The default of `100` is suitable for most datasets. Increase this value for large, high-dimensional datasets where a more stable score distribution is needed.
+
+## Returns
+
+The node returns the result as `byte[]`. Bind it to a variable using **Return variable name**, then pass it downstream to a file-write node, a database loader, or another processing step.
+
+The bytes are encoded in the format chosen by **Output file format** (`csv` or `parquet`).

--- a/articles/flow/actions/machine-learning/overview.md
+++ b/articles/flow/actions/machine-learning/overview.md
@@ -1,5 +1,19 @@
 # Machine Learning overview
 
-Flow includes built-in support for time series forecasting through the [Prophet forecast](./prophet-forecast.md) action — based on the [Prophet](https://facebook.github.io/prophet/) algorithm developed by Meta. Use it to predict future values for business metrics that change over time, such as sales, demand, or operating costs. Prophet handles seasonal patterns, missing data, public holidays (by country code), custom events, and produces uncertainty bands alongside each forecast. It can also generate separate forecasts per product, region, or cost center from a single dataset.
+Flow includes built-in machine learning actions for two common business problems: forecasting future values for time-varying metrics, and detecting anomalies in tabular datasets. Both actions run on the Forecast ML service and accept the same input types — `byte[]`, `Stream`, `DataTable`, or `IDataReader` — typically supplied by a file read action (CSV or Parquet from [OneDrive](../onedrive/overview.md), [Azure Blob Storage](../azure-blob-storage/overview.md), or similar) or a database query. Results are returned as files in CSV or Parquet format.
 
-The action accepts the historical data as a `byte[]`, `Stream`, `DataTable`, or `IDataReader` — typically from a file read action (CSV or Parquet from [OneDrive](../onedrive/overview.md), [Azure Blob Storage](../azure-blob-storage/overview.md), or similar) or a database query — and returns the forecast as a file. For best results, provide at least one full seasonal cycle of history (for example, 24+ months when forecasting monthly figures).
+[Prophet forecast](./prophet-forecast.md) is based on the [Prophet](https://facebook.github.io/prophet/) algorithm developed by Meta. Use it to predict future values for business metrics that change over time, such as sales, demand, or operating costs. Prophet handles seasonal patterns, missing data, public holidays (by country code), custom events, and produces uncertainty bands alongside each forecast. It can also generate separate forecasts per product, region, or cost center from a single dataset. For best results, provide at least one full seasonal cycle of history (for example, 24+ months when forecasting monthly figures).
+
+[Anomaly detection](./anomaly-detection.md) is based on the [Isolation Forest](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.IsolationForest.html) algorithm. Use it to flag unusual rows in a numeric dataset — fraudulent transactions, sensor readings outside expected ranges, data entry errors, or unusual demand patterns. Each anomalous row is returned with an anomaly score and a SHAP-based explanation that names the features driving the classification, so reviewers can act on the result without reverse-engineering the model.
+
+## Explore
+
+#### Prophet forecast
+Generates time series forecasts with seasonality, holidays, and uncertainty bands. Supports grouped forecasts across products, regions, or cost centers.
+[Read more](./prophet-forecast.md)
+<br/>
+
+#### Anomaly detection
+Identifies unusual rows in a numeric dataset using Isolation Forest, with a SHAP-based explanation of which features drove each classification.
+[Read more](./anomaly-detection.md)
+<br/>

--- a/articles/flow/actions/machine-learning/toc.yml
+++ b/articles/flow/actions/machine-learning/toc.yml
@@ -1,2 +1,4 @@
+- name: Anomaly detection
+  href: anomaly-detection.md
 - name: Prophet forecast
   href: prophet-forecast.md

--- a/articles/flow/actions/overview.md
+++ b/articles/flow/actions/overview.md
@@ -14,7 +14,7 @@ Flow includes a wide library of built-in actions, organized into categories belo
 <br/>
 
 #### AI and machine learning
-Flow integrates with the major LLM providers and supports building AI agents, generating embeddings, and using AI tools. [Agents](./agents/overview.md) provides chat agents and reusable AI components. [AI](./ai/overview.md) covers shared helpers such as text splitting and chat history management. [OpenAI](./openai/overview.md), [Anthropic AI](./anthropic/overview.md), [Azure AI](./azure-ai/overview.md), and [Google VertexAI](./google-vertexai/overview.md) provide chat completions, embeddings, and chat models for the respective providers. [Tavily](./tavily/overview.md) brings real-time web search into agents and flows. [Model Context Protocol (MCP)](./mcp/overview.md) lets Flow connect to external MCP servers and use the tools they expose. [Markdown](./markdown/overview.md) collects all conversion actions used to prepare documents for AI workflows. [Machine Learning](./machine-learning/overview.md) provides time series forecasting through the Prophet algorithm.
+Flow integrates with the major LLM providers and supports building AI agents, generating embeddings, and using AI tools. [Agents](./agents/overview.md) provides chat agents and reusable AI components. [AI](./ai/overview.md) covers shared helpers such as text splitting and chat history management. [OpenAI](./openai/overview.md), [Anthropic AI](./anthropic/overview.md), [Azure AI](./azure-ai/overview.md), and [Google VertexAI](./google-vertexai/overview.md) provide chat completions, embeddings, and chat models for the respective providers. [Tavily](./tavily/overview.md) brings real-time web search into agents and flows. [Model Context Protocol (MCP)](./mcp/overview.md) lets Flow connect to external MCP servers and use the tools they expose. [Markdown](./markdown/overview.md) collects all conversion actions used to prepare documents for AI workflows. [Machine Learning](./machine-learning/overview.md) provides time series forecasting through the Prophet algorithm and anomaly detection through Isolation Forest.
 
 <br/>
 
@@ -59,7 +59,7 @@ For integrating with HTTP-based APIs that don't have a dedicated category. [HTTP
 <br/>
 
 #### Hypergene products
-[Hypergene InVision](./profitbase-invision/overview.md) covers the planning, budgeting, and forecasting platform — Calculation Flows, Dimensions, Data Stores, Work Process Versions, File Storage, and custom SQL/PowerShell scripts. [Hypergene Portfolios](./hypergene-portfolios/overview.md) integrates with Hypergene Portfolios.
+[Hypergene InVision](./profitbase-invision/overview.md) covers the planning, budgeting, and forecasting platform — Calculation Flows, Dimensions, Data Stores, Work Process Versions, File Storage, package deployment and upgrades, and custom SQL/PowerShell scripts. [Hypergene DevOps](./hypergene-devops/overview.md) manages whole InVision deployments through the AllSpark API — cloning customer environments for testing, or tearing them down when they're no longer needed. [Hypergene Portfolios](./hypergene-portfolios/overview.md) integrates with Hypergene Portfolios.
 
 <br/>
 

--- a/articles/flow/actions/profitbase-invision/deploy-package.md
+++ b/articles/flow/actions/profitbase-invision/deploy-package.md
@@ -5,8 +5,10 @@ Deploys a [Profitbase Store package](../../../invision/docs/package.md) to a fol
 ![Deploy Package](../../../../images/flow/invision-deploy-package.png)
 
 **Example** ![Example](../../../../images/strz.jpg)  
-This flow lets DevOps validate a package deployment on a clone of a customer solution before touching production. It [clones](../hypergene-devops/clone-invision-deployment.md) the customer's Hypergene InVision deployment from production, runs the **Deploy package** action against the clone (which may take hours), and passes the result to a custom [Function](../built-in/function.md) action ("Validate deployment") that checks the deployment against business rules. The [If](../built-in/if.md) action then branches on the validation result — on success, the clone is [deleted](../hypergene-devops/delete-invision-deployment.md) since it has served its purpose; on failure, an email is [sent](../microsoft-365-outlook/send-email.md) to the admin so they can investigate while the clone is preserved for inspection.
+This flow lets DevOps validate a package deployment on a clone of a customer solution before touching production. It [clones](../hypergene-devops/clone-invision-deployment.md) the customer's Hypergene InVision deployment from production, runs the **Deploy package** action against the clone, and passes the result to a custom [Function](../built-in/function.md) action ("Validate deployment") that checks the deployment against business rules. The [If](../built-in/if.md) action then branches on the validation result — on success, the clone is [deleted](../hypergene-devops/delete-invision-deployment.md) since it has served its purpose; on failure, an email is [sent](../microsoft-365-outlook/send-email.md) to the admin so they can investigate while the clone is preserved for inspection.
 
+> [!IMPORTANT]
+> Deploying a package typically takes between a few minutes and one hour, depending on the package size. Any Flow that runs longer than five minutes must be configured to run in long-running mode.
 
 <br/>
 

--- a/articles/flow/actions/profitbase-invision/overview.md
+++ b/articles/flow/actions/profitbase-invision/overview.md
@@ -39,6 +39,12 @@ These actions automate the lifecycle of a planning cycle. [Create Work Process V
 
 <br/>
 
+## Package management
+
+[Deploy package](./deploy-package.md) installs a Profitbase Store package (a `.pbpck` file) into a folder in an InVision instance — typically used to roll out a new release of a customer solution. [Upgrade package](./upgrade-package.md) upgrades an already installed package to a newer version using a `.pckup` upgrade file, and can also upgrade the package inside any versioned solutions it has been deployed into. For operations on whole InVision deployments — cloning a customer environment to test a deploy or upgrade before touching production, or tearing down a clone afterwards — see the [Hypergene DevOps](../hypergene-devops/overview.md) category.
+
+<br/>
+
 ## Running custom scripts
 
 When the standard actions don't cover what you need, two action groups let you run custom code inside the InVision environment. [Execute SQL Script](./sql-script/execute-sql-script.md), [Execute long-running SQL Script](./sql-script/execute-long-running-sql-script.md), [returning a single value](./sql-script/execute-sql-script-returning-single-value.md), or [returning a DataPackage](./sql-script/execute-sql-script-returning-datapackage.md) — pick the variant matching the expected runtime and result shape. [Execute PowerShell script](./powershell/execute-powershell-script.md) and [Execute long-running PowerShell script](./powershell/execute-long-running-powershell-script.md) do the same for PowerShell.


### PR DESCRIPTION
## Updates the Machine Learning category to cover the new Anomaly detection action. Closed #614 

- `articles/flow/actions/machine-learning/overview.md` — reframed as a two-action category overview. Added an Anomaly detection paragraph alongside the existing Prophet content, lifted the shared input-type description into a lead paragraph, and added an `## Explore` section matching the pattern used in `agents/overview.md` and `azure-ai/overview.md`.
- `articles/flow/actions/overview.md` — updated the Machine Learning entry in the *AI and machine learning* section to mention both algorithms.
- `articles/flow/actions/machine-learning/toc.yml` — added the new page to the section TOC.

## docs(flow): address review feedback on DevOps and package actions

- AllSpark connection: Api as dropdown (Dev/Prod), literal values for Tenant Id and Client Id
- Hypergene DevOps overview: cascading clone/delete behavior with connected Flow deployments
- Clone/Delete deployment: per-action notes on Flow deployment cascade
- Deploy package: corrected duration expectations (minutes to ~1h), added 5-min long-running rule
- profitbase-invision overview: new Package management section
- Flow actions hub overview: added Hypergene DevOps, expanded InVision capabilities