### PR TITLE
changes after review

### DIFF
--- a/articles/flow/actions/finago-office/paged-rest-api-request.md
+++ b/articles/flow/actions/finago-office/paged-rest-api-request.md
@@ -1,97 +1,137 @@
 # Finago Office REST API Request with paging
 
-Use the [Finago Office (24SevenOffice) API](https://rest-api.developer.24sevenoffice.com/doc/v1/) to retrieve paginated data.
+The `REST API Request with paging` action retrieves large, paginated datasets from the [Finago Office (24SevenOffice) REST API](https://rest-api.developer.24sevenoffice.com/doc/v1/). The action iterates through all pages returned by the API and fires once per page, so downstream actions process one page at a time without you needing to manage pagination logic.
 
-The **REST API request with paging** action enables you to interact with the **Finago Office REST API** to retrieve large, paginated datasets. This action simplifies working with endpoints that return multiple pages of data, such as transaction lines. Pagination is managed automatically, allowing you to focus on processing the data.
-
-![Finago Office REST API Paging](/images/flow/finagooffice-rest-api-paging.png)  
+![Flow example showing Paged REST API Request retrieving transaction lines, with Get JSON DataReader and Insert rows on the For each path, and Log error on the On Error path](/images/flow/finagooffice-rest-api-paging.png)
 
 **Example** ![Example](/images/strz.jpg)
 
-In the example above, a **paginated REST API Request** is used to retrieve transaction lines and insert them into an SQL Server table. Each result from the **REST API Request** is converted using the [JSON to DataReader](../json/get-json-datareader.md) action, and then inserted using the [SQL Server Insert](../sql-server/insert-data.md) action.
+In the example above, a **Paged REST API Request** retrieves transaction lines from the Finago Office API. For each page, the JSON response is converted to rows using the [Get JSON DataReader](../json/get-json-datareader.md) action, and the rows are [inserted into](../sql-server/insert-data.md) a SQL Server table. If a page fails, the **On Error** port routes to a **Log error** action instead of terminating the Flow.
+
+<br/>
+
+## When to use this
+
+- Retrieve transaction lines, general ledger entries, or other large datasets from Finago Office where the API returns results across multiple pages.
+- Build a nightly data sync that pulls all records from Finago Office into a SQL Server staging table for downstream reporting.
+- Process paginated API responses page-by-page to keep memory usage low, instead of loading the entire result set at once.
+
+Use the non-paging [REST API Request](./rest-api-request.md) action when the endpoint returns a single response that does not need pagination.
+
+## How it works
+
+- **Input**: An HTTP request definition (method, URI, optional parameters) and an authenticated [Connection](./connection.md) to the Finago Office REST API.
+- **Processing**: Flow authenticates using OAuth2 credentials, sends the request, and retrieves one page of results at a time. For each page, the action fires the **For each \<endpoint\>** exit port, passing the page data to downstream actions. Pagination continues until no more pages remain or the **Max page count** limit is reached. Flow handles API throttling (HTTP 429) automatically with retry logic.
+- **Output**: Each page is returned as the configured response type — either raw JSON (`HttpResponse<string>`) or a custom data type. After all pages have been processed (or on error), the **Continue** port fires.
+
+### Exit ports
+
+| Port | Fires when |
+|---|---|
+| **For each \<endpoint\>** | Once per page of results. The port name reflects the URI endpoint (for example, "For each transactionlines"). Downstream actions connected here run for every page. |
+| **On Error** | A page request failed after retries, or an exception occurred. Connected error-handling actions run per failed page without terminating the Flow. |
+| **Continue** | After all pages have been processed (or the action completes with an error that is not handled by On Error). |
+
+<br/>
+
+## Prerequisites
+
+- A Finago Office (24SevenOffice) subscription.
+- A **ClientId**, **ClientSecret**, and **OrganizationId** for your Finago Office account.
+- A configured [Finago Office Connection](./connection.md) in Flow. See [Create Finago Office Connection](./create-connection.md) for how to set one up dynamically.
 
 <br/>
 
 ## Properties
 
-| Name            | Required | Description          |
-|---------------- | -------- | ---------------------|
-| Title           | No | The title or name of the request.  |
-| Connection      | Yes | The [Finago Office Connection](./connection.md) used to make an authenticated request to the Finago Office REST API. |
-| Dynamic connection | No | Use this option if you need to use a connection created by the [Create Connection](./create-connection.md) action. |
-| Configuration   | Yes | Specifies the HTTP request to the Finago Office API, including the HTTP method, URL, parameters, and return type. |
-| Start page   | No | Offset to the starting page for data retrieval. Defaults to 1 if not specified. |
-| Items per page  | No | The number of items to retrieve per page. Defaults to 50 if not specified.  |
-| Max page count  | No | The maximum number of pages to fetch. Defaults to 9999 if not specified.      |
-| Description     | No | Additional notes or comments about the action or configuration.               |
+| Name | Required | Description |
+|---|---|---|
+| **Title** | No | Display name for the action on the canvas. |
+| **Connection** | Yes | The [Finago Office Connection](./connection.md) used to authenticate requests to the Finago Office REST API. |
+| **Dynamic connection** | No | Overrides the static **Connection** with credentials created at runtime by the [Create Finago Office Connection](./create-connection.md) action. When set, Flow uses the dynamic connection at runtime and the static **Connection** only at design time. |
+| **Configuration** | Yes | Defines the HTTP request to the API, including method, URI, parameters, and return type. See [Configuration](#configuration) below. |
+| **Start page** | No | Offset to the starting page for data retrieval. Defaults to `1`. |
+| **Items per page** | No | Number of items to retrieve per page. Defaults to `50`. |
+| **Max page count** | No | Maximum number of pages to fetch. Defaults to `9999`. |
+| **Disabled** | No | When set to `true`, the action is skipped during Flow execution. |
+| **Description** | No | Free-text notes about the action. |
 
-<br>
+<br/>
 
-## Returns  
+## Returns
 
-The return type is defined when configuring the action. It can be a custom data type set by the template, or the raw JSON response from the API.  
-We recommend using the built-in [HttpResponse&lt;T&gt;](../../api-reference/built-in-types/http-response.md) type because it will include additional information about the response, such as the HTTP status code and error(s).
+The return type is defined when configuring the action. It can be a custom data type set by the template, or the raw JSON response from the API.
 
-We recommend dumping the raw response into a data store and using data transformation tools to convert it into a usable format. If the API returns a relatively small dataset (10,000–200,000 records), consider using the [Get JSON DataReader](../json/get-json-datareader.md) to flatten the JSON into a tabular format. This allows you to process the data as rows and columns, such as by inserting it directly into a SQL Server table.
+Use the built-in [HttpResponse&lt;T&gt;](../../api-reference/built-in-types/http-response.md) type to get additional information about the response, including the HTTP status code and any errors.
+
+> [!TIP]
+> For large datasets, store the raw JSON response in a database or blob storage first, then use transformation tools (dbt, SQLMesh, or Azure Data Factory) to reshape the data. This avoids high memory usage from deserializing large payloads in Flow.
+
+If the API returns a relatively small number of records (10,000–200,000), you can use [Get JSON DataReader](../json/get-json-datareader.md) to flatten the JSON into a tabular format and process the data as rows and columns — for example, by inserting directly into a SQL Server table.
 
 <br/>
 
 ## Configuration
 
-To define a request to the Finago Office REST API, you can start from a template, or define it manually.
-If you press the `New Request` button in the Configuration dialog, you can choose from a set of predefined request templates.  
+To define a request to the Finago Office REST API, start from a template or define it manually.
 
-The Finago Office REST API is large, so the template collection contains only a subset of the available APIs. If you cannot find a template for the request you want to make, you can refer to the [Finago Office API documentation](https://rest-api.developer.24sevenoffice.com/doc/v1/) and define the request manually.
+### Using a template
 
-![New Request](/images/flow/dynamics365-bc-new-request.png)
+1. Open the **Configuration** dialog for the action.
+2. Click **New Request**.
+3. Choose from the list of predefined request templates.
 
-To define a request to the Finago Office REST API, you can start from a template, or define it manually:
-1. **Method**: Choose the appropriate HTTP method for your request:  
-   - `GET`: Retrieve data from Finago Office (e.g., get transaction lines).  
+<!-- TODO: Replace screenshot — currently shows Dynamics 365 BC template picker, not Finago Office. -->
+![New Request dialog showing predefined request templates](/images/flow/dynamics365-bc-new-request.png)
 
-2. **URI**: Specify the endpoint for your request. For example:  
-   - `transaction lines`: To manage transaction lines records.
+The template collection covers a subset of the available Finago Office APIs. If you cannot find a template for the request you need, see the [Finago Office REST API documentation](https://rest-api.developer.24sevenoffice.com/doc/v1/) and define the request manually.
 
-3. **Headers**: 
-   - Authentication is automatically set up from the connection settings.
+### Defining a request manually
 
-4. **Parameters**: Add query or body parameters as required by the endpoint. Use variables or fixed values based on your workflow to customize the request and ensure it retrieves or updates the desired data.  
+See the [Finago Office REST API documentation](https://rest-api.developer.24sevenoffice.com/doc/v1/) for available endpoints and parameters.
 
-5. **Response Type**: Use the default `HttpResponse<string>` to work with raw JSON data. For large datasets, this approach is recommended to reduce memory usage and improve performance.
+1. Set the **Method** (`GET`, `PUT`, `POST`, `DELETE`). Most endpoints that fetch data require `GET`.
+2. Set the **URI** — the API endpoint path, for example `transactionlines`. If the endpoint requires parameters, insert a Flow variable using the popup that appears when the URI editor gets focus.
+3. Add optional **Parameters** as query or body parameters required by the endpoint. Use variables or fixed values depending on your workflow.
+4. Define the **Response** type. The default is [HttpResponse&lt;string&gt;](../../api-reference/built-in-types/http-response.md), which returns the raw JSON. You can change this to a custom type, but deserialization allocates more memory and impacts performance for large datasets. For large datasets, store raw JSON and transform it downstream.
+
+> [!NOTE]
+> Flow sets authentication headers automatically from the Connection. You do not need to configure auth headers manually.
+
+<br/>
+
+## Response paging
+
+The action handles pagination automatically. It requests one page at a time and fires the **For each \<endpoint\>** exit port for each page, until the API returns no more pages or the **Max page count** is reached.
+
+This action also works with endpoints that do not return paginated responses. In that case, the **For each** port fires once with the complete result.
 
 <br/>
 
 ## Error handling
 
-If the response from the Finago Office REST API is set to [HttpResponse&lt;T&gt;](../../api-reference/built-in-types/http-response.md), the response object includes an `IsSuccess` property. When `IsSuccess` is false, the response has an `ErrorContent` property that relays the error messages from the API call or from internally thrown exceptions. 
+If the response type is set to [HttpResponse&lt;T&gt;](../../api-reference/built-in-types/http-response.md), the response object includes an `IsSuccess` property. When `IsSuccess` is `false`, the `ErrorContent` property contains the error messages from the API call or from internally thrown exceptions.
 
-For other response types and for severe errors, the action will raise an error that could terminate the Flow unless either the `On Error` port is connected, or it is wrapped in a [Try-Catch](../built-in/try-catch.md) action. 
+For other response types and for severe errors, the action raises an error that terminates the Flow unless either the **On Error** port is connected or the action is wrapped in a [Try-Catch](../built-in/try-catch.md) action.
 
-The `On Error` error handler will be triggered for each `page error`, allowing you to handle errors individually and preventing Flow from automatically raising an error that might terminate the running process.
-
-<br>
-
-## API Limits  
-
-Finago Office enforces rate limits to maintain stable server performance. If you exceed these limits, the API will return a `429 Too Many Requests` error.  
-The action handles this by delaying calls and retrying requests. If the retry limit is reached, an error is returned.
-
+The **On Error** handler fires for each failed page individually, so you can log or retry page-level errors without terminating the entire Flow.
 
 <br/>
 
-## Workflow Example  
+## API limits
 
-1. **Configure the Action**:  
-   - Define the API endpoint, such as `transaction lines`.  
-   - Add any required query parameters (eg. from and to date), including filters or sorting options.  
+Finago Office enforces rate limits to maintain stable server performance. If you exceed these limits, the API returns a `429 Too Many Requests` error.
 
-2. **Handle the Response**:  
-   - Process the data page-by-page, or store it for later transformation.  
-   - If necessary, handle errors or retry logic within your workflow.  
-
-3. **Post-Processing**:  
-   - Use tools like SQL or Python to analyze and transform the retrieved data into a usable format.  
+The action handles this automatically by delaying and retrying requests. If the retry limit is reached, an error is raised. You can handle this error in the **On Error** port — for example, by using the [Wait](../built-in/wait.md) action to pause before a manual retry.
 
 <br/>
 
-By using the **REST API Request with paging** action, you can effectively retrieve and handle large datasets from Finago Office while adhering to best practices for performance and API compliance.
+## See also
+
+- [REST API Request](./rest-api-request.md) — non-paging version for endpoints that return a single response.
+- [Finago Office Connection](./connection.md) — set up a static connection to the Finago Office API.
+- [Create Finago Office Connection](./create-connection.md) — create a connection dynamically at runtime.
+- [Get JSON DataReader](../json/get-json-datareader.md) — stream JSON as rows and columns without loading the full payload into memory.
+- [Insert Data](../sql-server/insert-data.md) — insert rows into a SQL Server table.
+- [HttpResponse&lt;T&gt;](../../api-reference/built-in-types/http-response.md) — built-in type that wraps an API response with status code and error details.
+- [Try-Catch](../built-in/try-catch.md) — wrap actions in error-handling logic.

--- a/articles/flow/actions/finago-office/rest-api-request.md
+++ b/articles/flow/actions/finago-office/rest-api-request.md
@@ -1,49 +1,108 @@
 # REST API Request
 
-The `REST API Request` action enables you to call [Finago Office (24SevenOffice) API](https://rest-api.developer.24sevenoffice.com/doc/v1/) and retrieve data. A typical use case is to create data integrations for pulling data from Finago Office/24SevenOffice into a data platform solution.
+The `REST API Request` action calls the [Finago Office (24SevenOffice) REST API](https://rest-api.developer.24sevenoffice.com/doc/v1/) and retrieves data. Use this action to pull data from Finago Office into a data platform, automate periodic data syncs, and build reporting pipelines over accounting, invoicing, and contact data.
 
-![24seven Office REST API](/images/flow/24SevenOffice-rest-api.png)
+![Finago Office REST API Request action showing Connection, Configuration, and exit ports for Success, Error, and Continue](/images/flow/24SevenOffice-rest-api.png)
 
 **Example** ![Example](../../../../images/strz.jpg)  
-The example above shows a Flow that use a [dynamic connection](./create-connection.md) to 'request accounts' . The json data in the response content is [converted to a table](../json/get-json-datatable.md) and the data is [inserted into](../sql-server/insert-data.md) an SQL server table.
+The example above shows a Flow that uses a [dynamic connection](./create-connection.md) to request accounts. The JSON data in the response is [converted to a table](../json/get-json-datatable.md), and the resulting rows are [inserted into](../sql-server/insert-data.md) a SQL Server table.
+
+<br/>
+
+## When to use this
+
+- Pull chart-of-accounts, general ledger transactions, invoices, or customer/vendor data from Finago Office into a SQL Server database or data warehouse.
+- Automate a nightly or weekly sync of financial data so reporting dashboards stay current without manual exports.
+- Extract data from Finago Office as part of a larger data integration pipeline that combines multiple source systems.
+
+## How it works
+
+- **Input**: A configured HTTP request (method, URI, optional query parameters) and an authenticated [Connection](./connection.md) to the Finago Office REST API.
+- **Processing**: Flow authenticates against the Finago Office API using OAuth2 credentials (ClientId, ClientSecret, OrganizationId), sends the HTTP request, and handles retry logic for API throttling automatically. You do not need to manage tokens or retry cycles.
+- **Output**: The response from the API, either as raw JSON (`HttpResponse<string>`) or a custom data type you define. The action routes execution to the **Success**, **Error**, or **Continue** exit port depending on the result.
+
+### Exit ports
+
+| Port | Fires when |
+|---|---|
+| **Success** | The API returned a successful response (HTTP 2xx). |
+| **Error** | The API returned an error, or an exception occurred during execution. |
+| **Continue** | Execution continues regardless of the outcome. |
+
+<!-- TODO: Verify exact behavior of Continue port — does it fire in addition to Success/Error, or only when neither fires? -->
+
+<br/>
+
+## Prerequisites
+
+- A Finago Office (24SevenOffice) subscription.
+- A **ClientId**, **ClientSecret**, and **OrganizationId** for your Finago Office account.
+- A configured [Finago Office Connection](./connection.md) in Flow. See [Create Finago Office Connection](./create-connection.md) for how to set one up dynamically.
 
 <br/>
 
 ## Properties
 
 <!--prettier-ignore-->
-| Name          | Required | Description                                                                                                                                                                          |
-| ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Connection    | Yes | The [connection](./connection.md) used to make an authenticated request to the Finago Office REST API. |
-| Dynamic connection | No | Use this option if You need to create a connection using different credentials stored outside the workspace (for example in your own database). It is also useful when To dynamically create a connection, use the [Create Finago Office Connection](./create-connection.md) action.  |
-| Configuration | Yes | Defines the HTTP request to make to the API. See details [below](#configuration).  |
-| Disabled      | No | Boolean value indicating whether the action is disabled (true/false). |
-| Description   | No | Additional details or notes about the action. |
+| Name | Required | Description |
+|---|---|---|
+| **Connection** | Yes | The [connection](./connection.md) used to authenticate requests to the Finago Office REST API. |
+| **Dynamic connection** | No | Overrides the static **Connection** with credentials stored outside the Workspace (for example, in your own database). To create a connection dynamically at runtime, use the [Create Finago Office Connection](./create-connection.md) action. |
+| **Configuration** | Yes | Defines the HTTP request to make to the API. See [Configuration](#configuration) below. |
+| **Disabled** | No | When set to `true`, the action is skipped during Flow execution. |
+| **Description** | No | Free-text notes about the action. |
 
 <br/>
 
 ## Returns
 
-The return type is defined when configuring the action. It can be a custom data type or the raw JSON response from the API.  
-We recommend using the built-in [HttpResponse&lt;T&gt;](../../api-reference/built-in-types/http-response.md) type because it will include additional information about the response, such as the HTTP status code and error(s).
+The return type is defined when configuring the action. It can be a custom data type or the raw JSON response from the API.
 
-We also recommend simply dumping the raw response to a data store, and then use data transformation tools to transform the data into a usable format. If you know the API returns small amounts of data (10 000 - 200 000 records), you can consider using the [Get JSON DataReader](../json/get-json-datareader.md) to flatten JSON to a tabular format and process the data as rows and columns, for example by inserting directly to a SQL Server table.
+Use the built-in [HttpResponse&lt;T&gt;](../../api-reference/built-in-types/http-response.md) type to get additional information about the response, including the HTTP status code and any errors.
+
+> [!TIP]
+> For large data sets (10,000–200,000+ records), store the raw JSON response in a database or blob storage first, then use transformation tools (dbt, SQLMesh, or Azure Data Factory) to reshape the data. This avoids high memory usage from deserializing large payloads in Flow.
+
+If you know the API returns a small number of records, you can use [Get JSON DataReader](../json/get-json-datareader.md) to flatten the JSON to a tabular format and process the data as rows and columns — for example, by inserting directly into a SQL Server table.
 
 <br/>
 
 ## Configuration
 
-To define a request to the REST API, you can start from a template, or define it manually.
-If you press the `New Request` button in the Configuration dialog, you can choose from a set of predefined request templates.  
-The template collection contains a subset of the available APIs. If you cannot find a template for the request you want to make, you can refer to the [API documentation](https://rest-api.developer.24sevenoffice.com/doc/v1/) and define the request manually.
+To define a request to the REST API, you can start from a template or define it manually.
 
-<br/>
+### Using a template
+
+1. Open the **Configuration** dialog for the action.
+2. Click **New Request**.
+3. Choose from the list of predefined request templates.
+
+The template collection covers a subset of the available APIs. If you cannot find a template for the request you need, see the [Finago Office REST API documentation](https://rest-api.developer.24sevenoffice.com/doc/v1/) and define the request manually.
 
 ### Defining a request manually
 
-To define a request manually, please refer to the [API documentation](https://rest-api.developer.24sevenoffice.com/doc/v1/) to learn which endpoint and parameters to use.
+See the [Finago Office REST API documentation](https://rest-api.developer.24sevenoffice.com/doc/v1/) for available endpoints and parameters.
 
-1. Define the `Method` (`GET`, `PUT`, `POST`, `DELETE`, etc ). Most APIs for fetching data requires the `GET` method.
-2. Define the `URI`. This is the API endpoint, for example `companies/{id}`. If a query requires parameters (for example the company id in this example), insert a variable from Flow using the popup that appears when the URI editor gets focus.
-3. Add optional `Query Parameters`. E.g. when requesting TransactionLines, add parameters for `dateFrom` and `dateTo` with date values (ISO format).
-4. Define the `Response`. The default response type is [HttpResponse&lt;string&gt;](../../api-reference/built-in-types/http-response.md). This means you get back the raw JSON response from the API. You can change the data type to a custom type if you want to, but keep in mind that this will allocate more memory and impact performance negatively for large data sets such as dimensions and general ledger queries. We recommend simply dumping the raw response to a data store (like a database or blob storage), and then use tools like dbt, SQLMesh or Azure Data Factory to transform the data into a usable format.
+1. Set the **Method** (`GET`, `PUT`, `POST`, `DELETE`, etc.). Most endpoints that fetch data require `GET`.
+2. Set the **URI** — the API endpoint path, for example `companies/{id}`. If the endpoint requires parameters (such as a company ID), insert a Flow variable using the popup that appears when the URI editor gets focus.
+3. Add optional **Query Parameters**. For example, when requesting transaction lines, add `dateFrom` and `dateTo` parameters with date values in ISO format.
+4. Define the **Response** type. The default is [HttpResponse&lt;string&gt;](../../api-reference/built-in-types/http-response.md), which returns the raw JSON. You can change this to a custom type, but keep in mind that deserialization allocates more memory and impacts performance for large data sets such as dimensions and general ledger queries.
+
+<br/>
+
+## Notes
+
+- Flow handles OAuth2 authentication and API throttling/retry automatically. You do not need to manage access tokens or implement backoff logic.
+- For large data sets, avoid deserializing into custom types directly. Store raw JSON first and transform it downstream.
+- The Finago Office REST API is versioned independently of Flow. Check the [API documentation](https://rest-api.developer.24sevenoffice.com/doc/v1/) for the latest available endpoints and any breaking changes.
+
+<br/>
+
+## See also
+
+- [Finago Office Connection](./connection.md) — set up a static connection to the Finago Office API.
+- [Create Finago Office Connection](./create-connection.md) — create a connection dynamically at runtime using credentials from a database or variable.
+- [Get JSON DataTable](../json/get-json-datatable.md) — convert a JSON string to a `DataTable` for tabular processing.
+- [Get JSON DataReader](../json/get-json-datareader.md) — stream JSON as rows and columns without loading the full payload into memory.
+- [Insert Data](../sql-server/insert-data.md) — insert rows into a SQL Server table.
+- [HttpResponse&lt;T&gt;](../../api-reference/built-in-types/http-response.md) — built-in type that wraps an API response with status code and error details.


### PR DESCRIPTION
# PR Review: Finago Office REST API documentation closing #633 

## Summary

Good foundation — both pages cover the core technical content and the Properties tables are more complete than some of the older integration pages. The main gaps are structural (missing template-required sections) and a few copy-paste artifacts from the Dynamics 365 BC pages these were adapted from.

I've drafted revised versions of both files with all the changes below applied. They're published to doublecheck.

---

## Must-fix

### Both pages

1. **Missing template sections.** Both pages are missing **When to use this**, **How it works**, **Prerequisites**, and **See also**. These are required by the per-action page template. Revised versions include all four.

2. **Banlist language.** Multiple instances across both pages:
   - "enables you to" → state what the action does directly
   - "We recommend" (first person) → imperative or second person
   - "please refer to" → "see"
   - "simply dumping" → "store the raw response in a database or blob storage"

3. **Exit ports not documented.** Both screenshots show exit ports (Success/Error/Continue on the non-paging action; For each/On Error/Continue on the paging action) that are not described anywhere in the text. Added exit port tables to both pages.

### `rest-api-request.md`

4. **Garbled sentence in Dynamic connection description.** Two fragments spliced together mid-sentence: "It is also useful when To dynamically create a connection, use the…" — unreadable. Rewritten.

5. **Capitalization error.** "if You need" → "if you need".

### `rest-api-request-with-paging.md`

6. **Wrong screenshot.** `![New Request](/images/flow/dynamics365-bc-new-request.png)` shows the Dynamics 365 BC template picker, not Finago Office. Added a `<!-- TODO -->` comment to flag it for replacement. Needs a Finago Office-specific screenshot before merge, or remove the image.

7. **Duplicate intro.** Two opening paragraphs that describe the same thing. Merged into one.

8. **"Workflow Example" section duplicates Configuration.** Restates the same steps in vaguer terms. Removed — the example screenshot and description at the top of the page already serve this purpose.

9. **Marketing closing paragraph.** "By using the REST API Request with paging action, you can effectively retrieve and handle large datasets from Finago Office while adhering to best practices for performance and API compliance." Removed.

---

## Should-fix

10. **Bold UI labels consistently.** Both pages use backtick formatting (`` `New Request` ``) for UI labels in some places and nothing in others. UI labels should be bolded per the style guide: **New Request**, **Method**, **URI**, **Response**, etc.

11. **Number formatting.** `rest-api-request.md` uses "10 000 - 200 000" (Scandinavian convention) in English text. Changed to "10,000–200,000".

12. **Alt text.** Both main screenshots have non-descriptive alt text ("24seven Office REST API", "Finago Office REST API Paging"). Replaced with descriptions of what the screenshot shows.

13. **Heading casing.** `rest-api-request-with-paging.md` uses `## API Limits` (title case). Repo convention is sentence case: `## API limits`.

14. **Add `Disabled` property** to the paging page — standard Flow property, present on the non-paging sibling but missing here.

15. **Add Response paging section** to the paging page. The action's defining feature (per-page iteration) deserves its own section, as on the D365 BC neighbour.

16. **Dynamic connection: runtime vs. design-time.** The D365 BC neighbour explains that "Flow will use the Dynamic connection at runtime, and Connection only at design time." The paging page omits this. Added.

17. **Image path convention.** Paging page uses absolute path `![Example](/images/strz.jpg)` while the non-paging sibling uses relative `![Example](../../../../images/strz.jpg)`. Not blocking — both work in DocFX — but inconsistent within the folder.

---

## Notes

- **`Title` property** appears on the paging page but not the non-paging sibling. If it exists on both actions, it should be added to `rest-api-request.md` as well. If it's paging-specific, no action needed.

- **Systemic gap across integration pages.** Both Finago Office pages and the Microsoft Fabric `rest-api-request.md` are all missing the same template sections (When to use this, How it works, Prerequisites, See also). This isn't unique to this PR — it's a pattern across the integration action category. Worth addressing across the board in a follow-up.

- **External API URL** `https://rest-api.developer.24sevenoffice.com/doc/v1/` is live and current (v0.57.1, last updated June 2026). No issue.

---

## Files changed

| File | Changes |
|---|---|
| `articles/flow/actions/finago-office/rest-api-request.md` | Added When to use this, How it works, Prerequisites, See also, exit ports table. Fixed garbled Dynamic connection description. Banlist cleanup. Numbered configuration steps. Improved alt text. |
| `articles/flow/actions/finago-office/rest-api-request-with-paging.md` | Added When to use this, How it works, Prerequisites, See also, Response paging, exit ports table. Removed duplicate intro, Workflow Example section, marketing closing. Fixed heading casing. Banlist cleanup. Added Disabled property, runtime/design-time note.  |
